### PR TITLE
Add more tests for resolver definition builder

### DIFF
--- a/Sources/SettlerFramework/DataStructures/ResolverDefinition.swift
+++ b/Sources/SettlerFramework/DataStructures/ResolverDefinition.swift
@@ -10,7 +10,7 @@ public typealias TypeNameChain = [TypeName]
 
 /// The definition of a type-alias. This may be the `Output` type-alias, or
 /// a member of the `Keys` enum.
-public struct TypeAliasDefinition {
+public struct TypeAliasDefinition: Equatable {
     public let name: TypeName
     public let existingType: TypeName
 }
@@ -22,7 +22,7 @@ public struct KeyDefinition {
 }
 
 /// A parameter to a function
-public struct FunctionParameter {
+public struct FunctionParameter: Equatable {
     public let name: String
     public let typeName: TypeName
 }
@@ -39,7 +39,7 @@ struct PartialFunctionDefinition {
 /// The definition for a Resolver function. A Resolver function is one that
 /// resolves a `Key` member by returning in, and takes only `Key` members
 /// as parameters.
-public struct ResolverFunctionDefinition {
+public struct ResolverFunctionDefinition: Equatable {
     public let name: String
     public let parameters: [FunctionParameter]
     public let returnType: TypeName
@@ -48,7 +48,7 @@ public struct ResolverFunctionDefinition {
 
 /// The definition for a config function. A config function is one that takes
 /// only `Key` members as parameters, and has a return type of `Void`.
-public struct ConfigFunctionDefinition {
+public struct ConfigFunctionDefinition: Equatable {
     public let name: String
     public let parameters: [FunctionParameter]
     public let isThrowing: Bool

--- a/Tests/SettlerTests/ResolverDefinitionBuilderTests.swift
+++ b/Tests/SettlerTests/ResolverDefinitionBuilderTests.swift
@@ -118,4 +118,146 @@ final class ResolverDefinitionBuilderTests: XCTestCase {
             .resolverFunctionContainsNonKeyParam, .noResolverFunctionForKey
         ], in: contents)
     }
+
+    func testErrorIsReturnedIfResolverHasDuplicateResolverFunctions() throws {
+        let contents = """
+        struct TestResolver: Resolver {
+            typealias Output = Key.Foo
+            enum Key {
+                typealias Foo = String
+            }
+            ↓func resolveFirstFoo() -> Key.Foo { "abc" }
+            ↓func resolveSecondFoo() -> Key.Foo { "123" }
+        }
+        """
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(contents.strippingMarkers)])
+        XCTAssertEqual(output.definitions.count, 0)
+        XCTAssertEqual(output.errors.count, 2)
+        assert(located: output.errors, contains: [
+            .duplicateReturnTypesInResolverFunctions,
+            .duplicateReturnTypesInResolverFunctions
+        ], in: contents)
+    }
+
+    func testDefinitionHasCorrectTypeChain() throws {
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(completeTestResolverContents)])
+        let definition = try XCTUnwrap(output.definitions[safe: 0])
+        XCTAssertEqual(output.definitions.count, 1)
+        XCTAssertEqual(output.errors.count, 0)
+        XCTAssertEqual(definition.typeChain, ["TestResolver"])
+    }
+
+    func testDefinitionHasCorrectKeys() throws {
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(completeTestResolverContents)])
+        let definition = try XCTUnwrap(output.definitions[safe: 0])
+        let keys = definition.keyDefinition.typeAliases.map(\.value)
+        let expectedKeys = [
+            TypeAliasDefinition(name: "Foo", existingType: "String"),
+            TypeAliasDefinition(name: "Bar", existingType: "Int")
+        ]
+        XCTAssertEqual(keys, expectedKeys)
+    }
+
+    func testDefinitionHasCorrectOutput() throws {
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(completeTestResolverContents)])
+        let definition = try XCTUnwrap(output.definitions[safe: 0])
+        let expectedOutput = TypeAliasDefinition(name: "Output", existingType: "Key.Foo")
+        XCTAssertEqual(definition.outputDefinition, expectedOutput)
+    }
+
+    func testDefinitionHasCorrectResolverFunctions() throws {
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(completeTestResolverContents)])
+        let definition = try XCTUnwrap(output.definitions[safe: 0])
+        let resolverFunctions = definition.resolverFunctions.map(\.value)
+        let expectedResolverFunctions = [
+            ResolverFunctionDefinition(name: "resolveFoo(bar:)", parameters: [
+                FunctionParameter(name: "bar", typeName: "Key.Bar")
+            ], returnType: "Key.Foo", isThrowing: false),
+            ResolverFunctionDefinition(name: "resolveBar()", parameters: [], returnType: "Key.Bar", isThrowing: false)
+        ]
+        XCTAssertEqual(resolverFunctions, expectedResolverFunctions)
+    }
+
+    func testDefinitionHasCorrectConfigFunctions() throws {
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: [.contents(completeTestResolverContents)])
+        let definition = try XCTUnwrap(output.definitions[safe: 0])
+        let expectedConfigFunctions = [
+            ConfigFunctionDefinition(name: "configure(foo:bar:)", parameters: [
+                FunctionParameter(name: "foo", typeName: "Key.Foo"),
+                FunctionParameter(name: "bar", typeName: "Key.Bar")
+            ], isThrowing: true)
+        ]
+        XCTAssertEqual(definition.configFunctions, expectedConfigFunctions)
+    }
+
+    func testDefinitionIsReturnedWithAnExtension() throws {
+        let declaration = """
+        struct TestResolver: Resolver {
+            typealias Output = Key.Foo
+            enum Key {
+                typealias Foo = String
+                typealias Bar = Int
+            }
+        }
+        """
+        let functions = """
+        extension TestResolver {
+            func resolveFoo(bar: Key.Bar) -> Key.Foo { "abc" }
+            func resolveBar() -> Key.Bar { 123 }
+        }
+        """
+        let contents: [FilePathOrContents] = [declaration, functions].map { .contents($0.strippingMarkers) }
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: contents)
+        XCTAssertEqual(output.definitions.count, 1)
+        XCTAssertEqual(output.errors.count, 0)
+    }
+
+    func testDefinitionIsReturnedForResolverWithNamespace() throws {
+        let declaration = """
+        enum Namespace {
+            struct TestResolver: Resolver {
+                typealias Output = Key.Foo
+                enum Key {
+                    typealias Foo = String
+                    typealias Bar = Int
+                }
+            }
+        }
+        """
+        let functions = """
+        extension Namespace.TestResolver {
+            func resolveFoo(bar: Key.Bar) -> Key.Foo { "abc" }
+            func resolveBar() -> Key.Bar { 123 }
+        }
+        """
+        let contents: [FilePathOrContents] = [declaration, functions].map { .contents($0.strippingMarkers) }
+        let output = try ResolverDefinitionBuilder.buildWith(pathsOrContents: contents)
+        XCTAssertEqual(output.definitions.count, 1)
+        XCTAssertEqual(output.errors.count, 0)
+        XCTAssertEqual(output.definitions[safe: 0]?.typeChain, ["Namespace", "TestResolver"])
+    }
+
+    // MARK: - Helpers
+
+    var completeTestResolverContents: String {
+        """
+        struct TestResolver: Resolver {
+            typealias Output = Key.Foo
+            enum Key {
+                typealias Foo = String
+                typealias Bar = Int
+            }
+
+            // Resolver functions
+            func resolveFoo(bar: Key.Bar) -> Key.Foo { "abc" }
+            func resolveBar() -> Key.Bar { 123 }
+
+            // Config functions
+            func configure(foo: Key.Foo, bar: Key.Bar) throws { print(foo) }
+
+            // Ignored functions
+            func thisIsIgnored(foo: Key.Foo, testing: String) { print(testing) }
+        }
+        """
+    }
 }


### PR DESCRIPTION
This also fixes a bug where a resolver extension with a dot-notation namespace was not parsed properly.